### PR TITLE
Update GitHub Actions workflows now that fixes are merged

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: 'Download development provisioning profile'
         if: matrix.name == 'ios'
-        uses: apple-actions/download-provisioning-profiles@v1
+        uses: ssrobins/download-provisioning-profiles@v2
         with:
           bundle-id: '*'
           profile-type: 'IOS_APP_DEVELOPMENT'
@@ -69,7 +69,7 @@ jobs:
 
       - name: 'Download App Store provisioning profile'
         if: matrix.name == 'ios'
-        uses: apple-actions/download-provisioning-profiles@v1
+        uses: ssrobins/download-provisioning-profiles@v2
         with:
           bundle-id: 'com.dnqpy.${{ env.app_name }}'
           profile-type: 'IOS_APP_STORE'
@@ -79,7 +79,7 @@ jobs:
 
       - name: Import Code-Signing Certificates
         if: matrix.name == 'ios' || matrix.name == 'macos'
-        uses: apple-actions/import-codesign-certs@v1
+        uses: apple-actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATES }}
           p12-password: ${{ secrets.APPLE_CERTIFICATES_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: 'Download development provisioning profile'
         if: matrix.name == 'ios'
-        uses: ssrobins/download-provisioning-profiles@v2
+        uses: apple-actions/download-provisioning-profiles@v2
         with:
           bundle-id: '*'
           profile-type: 'IOS_APP_DEVELOPMENT'
@@ -69,7 +69,7 @@ jobs:
 
       - name: 'Download App Store provisioning profile'
         if: matrix.name == 'ios'
-        uses: ssrobins/download-provisioning-profiles@v2
+        uses: apple-actions/download-provisioning-profiles@v2
         with:
           bundle-id: 'com.dnqpy.${{ env.app_name }}'
           profile-type: 'IOS_APP_STORE'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: 'Download development provisioning profile'
         if: matrix.name == 'ios'
-        uses: ssrobins/download-provisioning-profiles@v2
+        uses: apple-actions/download-provisioning-profiles@v1
         with:
           bundle-id: '*'
           profile-type: 'IOS_APP_DEVELOPMENT'
@@ -69,7 +69,7 @@ jobs:
 
       - name: 'Download App Store provisioning profile'
         if: matrix.name == 'ios'
-        uses: ssrobins/download-provisioning-profiles@v2
+        uses: apple-actions/download-provisioning-profiles@v1
         with:
           bundle-id: 'com.dnqpy.${{ env.app_name }}'
           profile-type: 'IOS_APP_STORE'
@@ -79,7 +79,7 @@ jobs:
 
       - name: Import Code-Signing Certificates
         if: matrix.name == 'ios' || matrix.name == 'macos'
-        uses: ssrobins/import-codesign-certs@v2
+        uses: apple-actions/import-codesign-certs@v1
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATES }}
           p12-password: ${{ secrets.APPLE_CERTIFICATES_PASSWORD }}


### PR DESCRIPTION
Now that these fixes are merged:
https://github.com/Apple-Actions/download-provisioning-profiles/pull/18
https://github.com/Apple-Actions/import-codesign-certs/pull/41

Switching from the forks back to the original repos.