### PR TITLE
Add VS Code configs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-vscode.cmake-tools",
+    "ms-vscode.cpptools"
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "ms-vscode.cmake-tools",
-    "ms-vscode.cpptools"
-  ],
-  "unwantedRecommendations": []
+    "ms-vscode.cpptools",
+    "vadimcn.vscode-lldb"
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "CMake: Launch (macOS / LLDB)",
+      "name": "CMake: Launch (macOS/Linux / LLDB)",
       "type": "lldb",
       "request": "launch",
       "program": "${command:cmake.launchTargetPath}",
@@ -17,24 +17,6 @@
         // "MY_VAR": "value"
       },
       "terminal": "integrated"
-    },
-        {
-      "name": "CMake: Launch (Linux / LLDB)",
-      "type": "lldb",
-      "request": "launch",
-      "program": "${command:cmake.launchTargetPath}",
-      "args": [
-        // Example: pass arguments to your program
-        // "arg1", "arg2=value", "--flag"
-      ],
-      "cwd": "${command:cmake.launchTargetDirectory}",
-      "stopOnEntry": false,
-      "env": {
-        // Example: set environment variables for your program
-        // "MY_VAR": "value"
-      },
-      "terminal": "integrated",
-      "MIMode": "lldb"
     },
     {
       "name": "CMake: Launch (Windows / MSVC)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,32 +2,37 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "CMake: Launch target (macOS / AppleClang)",
-      "type": "cppdbg",
+      "name": "CMake: Launch (macOS / LLDB)",
+      "type": "lldb",
       "request": "launch",
       "program": "${command:cmake.launchTargetPath}",
-      "args": [],
+      "args": [
+        // Example: pass arguments to your program
+        // "arg1", "arg2=value", "--flag"
+      ],
       "cwd": "${command:cmake.launchTargetDirectory}",
-      "stopAtEntry": false,
-      "MIMode": "${command:cmake.debuggerCommand}",
-      "environment": [],
-      "setupCommands": [
-        {
-          "description": "Enable pretty-printing",
-          "text": "-enable-pretty-printing",
-          "ignoreFailures": true
-        }
-      ]
+      "stopOnEntry": false,
+      "env": {
+        // Example: set environment variables for your program
+        // "MY_VAR": "value"
+      },
+      "terminal": "integrated"
     },
     {
-      "name": "CMake: Launch target (Windows - MSVC)",
+      "name": "CMake: Launch (Windows / MSVC)",
       "type": "cppvsdbg",
       "request": "launch",
       "program": "${command:cmake.launchTargetPath}",
-      "args": [],
+      "args": [
+        // Example: pass arguments to your program
+        // "arg1", "arg2=value", "--flag"
+      ],
       "cwd": "${command:cmake.launchTargetDirectory}",
       "stopAtEntry": false,
-      "environment": []
+      "environment": [
+        // Example: set environment variables for your program
+        // { "name": "MY_VAR", "value": "value" }
+      ]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "CMake: Launch target (macOS / AppleClang)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [],
+      "cwd": "${command:cmake.launchTargetDirectory}",
+      "stopAtEntry": false,
+      "MIMode": "${command:cmake.debuggerCommand}",
+      "environment": [],
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    },
+    {
+      "name": "CMake: Launch target (Windows - MSVC)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [],
+      "cwd": "${command:cmake.launchTargetDirectory}",
+      "stopAtEntry": false,
+      "environment": []
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,24 @@
       },
       "terminal": "integrated"
     },
+        {
+      "name": "CMake: Launch (Linux / LLDB)",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [
+        // Example: pass arguments to your program
+        // "arg1", "arg2=value", "--flag"
+      ],
+      "cwd": "${command:cmake.launchTargetDirectory}",
+      "stopOnEntry": false,
+      "env": {
+        // Example: set environment variables for your program
+        // "MY_VAR": "value"
+      },
+      "terminal": "integrated",
+      "MIMode": "lldb"
+    },
     {
       "name": "CMake: Launch (Windows / MSVC)",
       "type": "cppvsdbg",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,8 +9,7 @@
         {
             "name": "default",
             "hidden": true,
-            "binaryDir": "${sourceDir}/build_${presetName}",
-            "cmakeExecutable": "cmake.exe"
+            "binaryDir": "${sourceDir}/build_${presetName}"
         },
         {
             "name": "androidarm",

--- a/cmake/global_settings.cmake
+++ b/cmake/global_settings.cmake
@@ -102,3 +102,18 @@ set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/_install)
 set(CPACK_PACKAGE_DIRECTORY ${PROJECT_BINARY_DIR}/_package/\${CPACK_BUILD_CONFIG})
 set(CPACK_COMPONENTS_GROUPING IGNORE)
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
+
+# Fix for VS Code's Quick Debugging error "No compiler found in the cache file."
+# when using CMake's Xcode generator.
+# Note: Quick Debugging is the "Launch the debugger" icon in the status bar at the bottom,
+# not to be confused with "Start Debugging" in the Run menu and in the "Run and Debug"
+# Activity Bar, which is controlled by .vscode/launch.json")
+if(CMAKE_GENERATOR MATCHES "Xcode" AND NOT DEFINED CMAKE_COMPILER_FORCED)
+    foreach(lang C CXX)
+        set(CMAKE_${lang}_COMPILER "${CMAKE_${lang}_COMPILER}" 
+            CACHE STRING "Detected ${lang} compiler" FORCE)
+    endforeach()
+
+    set(CMAKE_COMPILER_FORCED TRUE CACHE INTERNAL "Mark compiler as forced")
+endif()
+


### PR DESCRIPTION
Add easy debugging in VS Code for Windows, macOS, and Linux apps. Also, add all extensions I used in the "recommendations" so they're more discoverable for developers to install.